### PR TITLE
Removed generic fields from migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,22 @@ Installation is quite simple.
     $ pip install mezzanine-file-collections
 
 Add "mezzanine_file_collections" to your list of installed apps. Then migrate
-your database. That's it.
+your database. 
+
+Add the desired file types to FILEBROWSER_EXTENSIONS on settings.py. Example:
+
+```
+FILEBROWSER_EXTENSIONS = {
+    'Folder': [''],
+    'Image': ['.jpg','.jpeg','.gif','.png','.tif','.tiff'],
+    'Video': ['.mov','.wmv','.mpeg','.mpg','.avi','.rm'],
+    'Document': ['.pdf','.doc','.rtf','.txt','.xls','.csv'],
+    'Audio': ['.mp3','.mp4','.wav','.aiff','.midi','.m4p', '.ogg'],
+    'Code': ['.html','.py','.js','.css']
+}
+```
+
+That's it.
 
 ## Usage
 

--- a/mezzanine_file_collections/migrations/0001_initial.py
+++ b/mezzanine_file_collections/migrations/0001_initial.py
@@ -83,7 +83,7 @@ class Migration(SchemaMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'in_menus': ('mezzanine.pages.fields.MenusField', [], {'default': '(1, 2, 3)', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'in_sitemap': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'keywords': ('mezzanine.generic.fields.KeywordsField', [], {'object_id_field': "'object_pk'", 'to': u"orm['generic.AssignedKeyword']", 'frozen_by_south': 'True'}),
+            #'keywords': ('mezzanine.generic.fields.KeywordsField', [], {'object_id_field': "'object_pk'", 'to': u"orm['generic.AssignedKeyword']", 'frozen_by_south': 'True'}),
             'keywords_string': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
             'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['pages.Page']"}),


### PR DESCRIPTION
These generic type fields aren't compatible with latest Django 1.6, and are not really necessary with latest versions of South.